### PR TITLE
Update of Polish translation

### DIFF
--- a/src/main/resources/assets/corpse/lang/pl_pl.json
+++ b/src/main/resources/assets/corpse/lang/pl_pl.json
@@ -17,5 +17,6 @@
   "tooltip.corpse.death_date": "Gracz zmarł %s",
   "tooltip.corpse.item_count": "Zawiera stacków: %s",
   "button.corpse.transfer_items": "Przenieś przedm.",
-  "button.corpse.additional_items": "Dodatkowe rzeczy"
+  "button.corpse.additional_items": "Dodatkowe rzeczy",
+  "config.jade.plugin_corpse.corpse": "Zwłoki"
 }


### PR DESCRIPTION
In this pull request, I updated the Polish translation to reflect the changes from commit 33d6f6a857e79ed30487394d041a8a15df69a61e.

I assumed that "Corpse" in this case is just the name of the entity, not a proper noun (i.e. the name of the mod) and I translated it under that assumption. Is it correct?