### PR TITLE
Janky/Dirty fix for issue #115

### DIFF
--- a/src/main/java/de/maxhenkel/corpse/gui/GUICorpse.java
+++ b/src/main/java/de/maxhenkel/corpse/gui/GUICorpse.java
@@ -58,9 +58,17 @@ public class GUICorpse extends GUIBase {
             CommonProxy.simpleNetworkWrapper.sendToServer(new MessageSwitchInventoryPage(page));
         } else if (button.id == 1) {
             page++;
+            //Dirty Fix to fix this issue: https://github.com/henkelmax/corpse/issues/115
+            //No way any mod would require more than 200 54 slot pages, make that be a sanity limit to prevent 1 million page or some shit
+            if(page >= 200) {
+            	page = 200;
+            }
+            /* 
             if (page >= getPages()) {
                 page = getPages() - 1;
             }
+            */
+            System.out.println("Requesting server send me page = " + page);
             CommonProxy.simpleNetworkWrapper.sendToServer(new MessageSwitchInventoryPage(page));
         }
     }
@@ -73,11 +81,13 @@ public class GUICorpse extends GUIBase {
         } else {
             previous.enabled = true;
         }
-
-        if (page >= getPages() - 1) {
-            next.enabled = false;
-        } else {
-            next.enabled = true;
+        //Dirty Fix to fix this issue: https://github.com/henkelmax/corpse/issues/115
+        //200 page limit is just a sanity check more than anything.
+        //if (page >= getPages() - 1) {
+        if(page >= 200) {
+        	next.enabled = false;
+        }else {
+        	next.enabled = true;
         }
     }
 


### PR DESCRIPTION
Client-side only change, as it only changes the GUICorpse.java file, which is client-side only.

Allows the player to continue to click through pages, up to page 200 no matter what data the server sends about how many slots are in corpse.getSizeInventory().

This is done because once a corpse is unloaded/reloaded, the server will always tell the client there is only 54 slots (1 page). I wasn't able to find where exactly this logic is to fix the root issue, and honestly I don't care to as this solution works fine for me.

If you don't implement this change, I would like to request permission to upload this recompiled version of the 1.12.2 corpse mod to Curse myself so others can access a fixed version without having to re-compile themselves like I did.

Also worth noting I tested this on my private server running the TNFC modpack and it worked correctly, I was able to retrieve the items off of my corpse and finally allow the corpse to actually despawn. (Without this fix, corpses will NEVER despawn since the 2nd+ page will always have items.)