### PR TITLE
Minor Polish translation improvements

### DIFF
--- a/src/main/resources/assets/corpse/lang/pl_pl.json
+++ b/src/main/resources/assets/corpse/lang/pl_pl.json
@@ -16,7 +16,7 @@
   "tooltip.corpse.teleport": "Teleportuj",
   "tooltip.corpse.death_date": "Gracz zmarł %s",
   "tooltip.corpse.item_count": "Zawiera stacków: %s",
-  "button.corpse.transfer_items": "Przenieś przedm.",
-  "button.corpse.additional_items": "Dodatkowe rzeczy",
+  "button.corpse.transfer_items": "Przenieś",
+  "button.corpse.additional_items": "Dodatkowe",
   "config.jade.plugin_corpse.corpse": "Zwłoki"
 }


### PR DESCRIPTION
I have always done my best to ensure the highest possible standards of the translations I maintain. But despite everything, I still haven't avoided a stupid mistake, which, although not tragic, should still be corrected.

When a player has more than a certain number of items in their inventory at the time of death, the ones that do not fit end up on another page of the Corpse GUI. In such case, two shorter buttons appear at the bottom in place of the longer one, which requires their labels to be short enough to fit there, which... I didn't foresee in the Polish translation I maintain (as you can see in the attached screenshot at the bottom).

This could have been avoided if the 4x9 inventory grid had been scrollable (like the creative mode menu) instead of being divided into pages because then there would be no need to add any additional buttons to go to the next page, and the problem of space for shorter labels would solve itself.

In the current situation, however, it seems to me that the best solution is to shorten these two problematic labels as follows:
- "Transfer Items" → "Transfer"
- "Additional Items" → "Additional"

They do lose some of their clarity, that's true, but only a little and I'm somewhat forced to make this sacrifice because the constantly moving text is a bit distracting (especially in this case), and even if it wasn't, version 1.19.3 and older do not support the new scrollable text. And I believe it would be worth backporting these changes there while you still support those older versions.

Speaking of which, if this translation gets accepted in the main branch, may I ask you to cherry-pick these changes for the versions you still support? The patch should apply cleanly, as nothing has changed in the source translation strings since you added support for Jade in 1.19.0.

TL;DR: Too long button labels bad (see below), sacrifices have been made to make the strings shorter, please approve this PR and at least read the paragraph above :)

![Too-long-button-labels](https://github.com/user-attachments/assets/7ada9a15-2bbb-4b62-a6b2-223078368984)