### PR TITLE
Polish translation update

### DIFF
--- a/src/main/resources/assets/corpse/lang/pl_pl.json
+++ b/src/main/resources/assets/corpse/lang/pl_pl.json
@@ -11,10 +11,12 @@
   "key.corpse.death_history": "Otwórz historię śmierci gracza",
   "message.corpse.no_death_history": "Brak historii śmierci gracza",
   "chat.corpse.teleport_death_location": "Teleportuj do miejsca śmierci %s",
-  "tooltip.corpse.teleport": "Teleportuj",
+  "tooltip.corpse.teleport": "Kliknij, aby się teleportować",
   "tooltip.corpse.death_date": "Gracz zmarł %s",
   "tooltip.corpse.item_count": "Zawiera stacków: %s",
   "button.corpse.transfer_items": "Przenieś",
   "button.corpse.additional_items": "Dodatkowe",
+  "button.corpse.add_waypoint": "Dodaj waypoint",
+  "waypoint.death.name": "Miejsce śmierci",
   "config.jade.plugin_corpse.corpse": "Zwłoki"
 }


### PR DESCRIPTION
In this pull request, I updated the Polish translation to include all the new and updated text strings from commit c098d8aff2ac02abddf4fc8760cbf3b078ab5e6b.

<sub>Just a quick note for you or other translators who might be reading this — the translation of the text string in the recently added `waypoint.death.name` key can be copied from the `message.gravestone.deathlocation` key in the Gravestone mod, as they both use exactly the same text. I'm not sure if the license allows for that though, but if you're the author of both translations like I am, it shouldn't be an issue...</sub>