### PR TITLE
Fix async death cleanup causing ServerPlayer clone leaks

### DIFF
--- a/src/main/java/de/maxhenkel/corpse/events/DeathEvents.java
+++ b/src/main/java/de/maxhenkel/corpse/events/DeathEvents.java
@@ -35,7 +35,7 @@ public class DeathEvents {
         }
         long ageInMillis = ((long) ageInDays) * 24L * 60L * 60L * 1000L;
         //TODO Use an executor
-        new Thread(() -> DeathManager.removeDeathsOlderThan(serverWorld, ageInMillis)).start();
+        serverWorld.getServer().execute(() -> DeathManager.removeDeathsOlderThan(serverWorld, ageInMillis));
     }
 
 }


### PR DESCRIPTION
I removed the async Thread and exchanged it with an execute.
I testet it on my server an there are no memory leaks anymore.